### PR TITLE
Add TLS support for exporters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1104,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
 name = "opentelemetry"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,6 +1526,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1537,6 +1574,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+dependencies = [
+ "base64",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,10 +1641,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+dependencies = [
+ "bitflags 2.5.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -1652,6 +1776,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,6 +1878,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,8 +1933,11 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "socket2 0.5.7",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -1885,6 +2035,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2190,3 +2346,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "either"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,6 +1079,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,13 +1251,16 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
+ "port_check",
  "prometheus",
  "prost",
+ "rcgen",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
  "tonic",
+ "uuid",
 ]
 
 [[package]]
@@ -1272,6 +1290,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64",
+ "serde",
 ]
 
 [[package]]
@@ -1353,6 +1381,18 @@ dependencies = [
  "tracing",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "port_check"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2110609fb863cdb367d4e69d6c43c81ba6a8c7d18e80082fe9f3ef16b23afeed"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1450,6 +1490,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48406db8ac1f3cbc7dcdb56ec355343817958a356ff430259bb07baf7607e1e1"
+dependencies = [
+ "pem",
+ "ring",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -1834,6 +1886,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,6 +2122,15 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -2346,6 +2426,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,13 @@ tonic = { version = "0.12", features = ["tls-native-roots"] }
 [dev-dependencies]
 async-trait = "0.1"
 opentelemetry-proto = { version = "0.7", features = ["gen-tonic", "metrics", "logs"] }
+port_check="0.2"
 prost = "0.13"
+rcgen = "0.12"
 reqwest = { version = "0.12", default-features = false }
 tonic = { version = "0.12", features = ["codegen", "prost","tls-native-roots"] }
 tokio = { version= "1.3", features = ["parking_lot"] }
+uuid = { version = "1", features = ["v4"] }
 [lints.rust]
 rust_2018_idioms = "warn"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ nix = { version = "0.27", default-features = false, features = [
 	"process", "hostname",
 ] }
 opentelemetry = { version = "0.24", features = ["metrics", "logs"]}
-opentelemetry-otlp = { version ="0.17", features = ["grpc-tonic", "metrics", "logs"]}
+opentelemetry-otlp = { version ="0.17", features = ["grpc-tonic", "metrics", "logs", "tls"]}
 opentelemetry-prometheus = {version = "0.17" }
 opentelemetry_sdk =  {version = "0.24", features = ["metrics", "logs", "rt-tokio", "testing", "logs_level_enabled"]}
 opentelemetry-stdout =  {version = "0.5", features = ["metrics"]}
@@ -31,15 +31,15 @@ serde = { version = "1", features = [
 serde_json = { version = "1.0", default-features = false, features = [
 	"alloc",
 ] }
+tonic = { version = "0.12", features = ["tls-native-roots"] }
 
 [dev-dependencies]
 async-trait = "0.1"
 opentelemetry-proto = { version = "0.7", features = ["gen-tonic", "metrics", "logs"] }
 prost = "0.13"
 reqwest = { version = "0.12", default-features = false }
-tonic = { version = "0.12", features = ["codegen", "prost"] }
+tonic = { version = "0.12", features = ["codegen", "prost","tls-native-roots"] }
 tokio = { version= "1.3", features = ["parking_lot"] }
-
 [lints.rust]
 rust_2018_idioms = "warn"
 

--- a/examples/sample-app/Cargo.lock
+++ b/examples/sample-app/Cargo.lock
@@ -535,6 +535,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,6 +1189,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
 name = "opentelemetry"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,6 +1320,7 @@ dependencies = [
  "prometheus",
  "serde",
  "serde_json",
+ "tonic",
 ]
 
 [[package]]
@@ -1546,6 +1569,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,6 +1617,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+dependencies = [
+ "base64",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,10 +1698,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+dependencies = [
+ "bitflags 2.5.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -1708,10 +1833,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1787,6 +1924,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,8 +1979,11 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "socket2 0.5.7",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -1915,6 +2066,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "utf8parse"
@@ -2185,3 +2342,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/examples/sample-app/src/main.rs
+++ b/examples/sample-app/src/main.rs
@@ -21,7 +21,8 @@ mod metrics;
 
 #[tokio::main]
 async fn main() {
-    // App expects 2 parameters. 1) '-n' that controls the number of iterations, and 2) '-o' to specify an otel compatible repo.
+    // App expects 3 parameters. 1) '-n' that controls the number of iterations, 2) '-o' to specify an otel compatible repo
+    // 3) '-c' to specify the path to the CA cert.
     let args = Args::parse();
 
     let prometheus_config = Some(Prometheus { port: 9090 });
@@ -32,12 +33,14 @@ async fn main() {
                 interval_secs: 1,
                 timeout: 5,
                 temporality: Some(Temporality::Cumulative),
+                ca_cert_path: args.ca_cert_path.clone(),
             }];
             let logs_targets = vec![LogsExportTarget {
                 url,
                 interval_secs: 1,
                 timeout: 5,
                 export_severity: Some(Severity::Error),
+                ca_cert_path: args.ca_cert_path,
             }];
             (Some(metric_targets), Some(logs_targets))
         }
@@ -103,4 +106,8 @@ struct Args {
     /// Otel Repository URL
     #[arg(short, long)]
     pub otel_repo_url: Option<String>,
+
+    /// Otel Repository URL
+    #[arg(short, long)]
+    pub ca_cert_path: Option<String>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,7 +72,7 @@ pub struct MetricsExportTarget {
     pub timeout: u64,
     /// export temporality preference, defaults to cumulative if not specified.
     pub temporality: Option<Temporality>,
-    /// path to root ca cert
+    /// path to the ca cert
     pub ca_cert_path: Option<String>,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,8 @@ pub struct MetricsExportTarget {
     pub timeout: u64,
     /// export temporality preference, defaults to cumulative if not specified.
     pub temporality: Option<Temporality>,
+    /// path to root ca cert
+    pub ca_cert_path: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -85,6 +87,8 @@ pub struct LogsExportTarget {
     pub timeout: u64,
     /// export severity - severity >= which to export
     pub export_severity: Option<Severity>,
+    /// path to root ca cert
+    pub ca_cert_path: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -132,12 +136,14 @@ mod tests {
             interval_secs: 1,
             timeout: 5,
             temporality: Some(Temporality::Cumulative),
+            ca_cert_path: None,
         }];
         let logs_targets = vec![LogsExportTarget {
             url: log_url,
             interval_secs: 1,
             timeout: 5,
             export_severity: Some(Severity::Error),
+            ca_cert_path: None,
         }];
 
         let config = Config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use opentelemetry_sdk::{
     runtime, Resource,
 };
 
-// TODO: evaluate if we should keep supporting writing metrics to stdout. 
+// TODO: evaluate if we should keep supporting writing metrics to stdout.
 use opentelemetry_stdout::MetricsExporterBuilder;
 
 use prometheus::{Encoder, Registry, TextEncoder};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,10 @@ use opentelemetry_sdk::{
     },
     runtime, Resource,
 };
+
+// TODO: evaluate if we should keep supporting writing metrics to stdout. 
 use opentelemetry_stdout::MetricsExporterBuilder;
+
 use prometheus::{Encoder, Registry, TextEncoder};
 use tonic::transport::{Certificate, ClientTlsConfig};
 
@@ -284,6 +287,10 @@ fn handle_tls(
                 Ok(ca_cert) => {
                     let ca_cert = Certificate::from_pem(ca_cert);
                     let tls_config = ClientTlsConfig::new().ca_certificate(ca_cert);
+                    // TODO: Evaluate using an alternative mechanism for TLS to use OpenSSL instead of rustls.
+                    // This could mean using `with_channel` instead of `with_tls_config` or switching away
+                    // from gRPC to JSON/HTTPS.
+
                     Ok(exporter_builder.with_tls_config(tls_config))
                 }
                 Err(e) => {

--- a/src/loggers.rs
+++ b/src/loggers.rs
@@ -21,6 +21,7 @@ use opentelemetry_sdk::{
     logs::{BatchConfigBuilder, BatchLogProcessor, LoggerProvider},
     runtime, Resource,
 };
+use tonic::transport::{Certificate, ClientTlsConfig};
 
 pub(crate) struct OtelLogBridge<P, L>
 where
@@ -125,8 +126,28 @@ pub(crate) fn init_logs(config: Config) -> Result<LoggerProvider, log::SetLogger
 
     if let Some(export_target_list) = config.log_export_targets {
         for export_target in export_target_list {
-            let exporter = match opentelemetry_otlp::new_exporter()
-                .tonic()
+            let mut exporter_builder = opentelemetry_otlp::new_exporter().tonic();
+            if export_target.url.starts_with("https") || export_target.url.starts_with("grpcs") {
+                if let Some(ca_cert_path) = export_target.ca_cert_path {
+                    let ca_cert = std::fs::read(ca_cert_path);
+                    match ca_cert {
+                        Ok(ca_cert) => {
+                            let ca_cert = Certificate::from_pem(ca_cert);
+                            let tls_config = ClientTlsConfig::new().ca_certificate(ca_cert);
+                            exporter_builder = exporter_builder.with_tls_config(tls_config);
+                        }
+                        Err(e) => {
+                            eprintln!("unable to load ca_cert_file {e:?}");
+                            continue;
+                        }
+                    }
+                }
+            } else {
+                exporter_builder =
+                    exporter_builder.with_tls_config(ClientTlsConfig::new().with_native_roots());
+            }
+
+            let exporter = match exporter_builder
                 .with_endpoint(export_target.url.clone())
                 .build_log_exporter()
             {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4,10 +4,11 @@
 #![deny(rust_2018_idioms)]
 #![warn(clippy::all, clippy::pedantic)]
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use log::{debug, error, info, trace, warn};
-use mocks::MockServer;
+use mocks::{generate_self_signed_cert, MockServer};
 use opentelemetry::{global, logs::Severity, metrics::MeterProvider};
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
@@ -19,40 +20,56 @@ use otel_lib::{
     config::{Attribute, Config, LogsExportTarget, MetricsExportTarget, Prometheus},
     Otel,
 };
-
+use port_check::free_local_port_in_range;
 use tokio::sync::mpsc::Receiver;
 use tokio::time::timeout;
 
 mod mocks;
 
-#[tokio::test]
 // This test does the following
-// 1) setup two mock otlp servers, one for filtered logs and the other for unfiltered logs
+// 1) setup four mock otlp servers, two for filtered logs (with TLS and without) and the other 2 for unfiltered logs
 // 2) configure the otel-lib to
 //    a) log at the `warn` level
 //    b) export logs to the filtered server the `error` level.
-//    c) export all logs to the unfiltered server
-//    d) export metrics to the filtered server
+//    c) export all logs to the unfiltered servers
+//    d) export metrics to the filtered servers
 //    e) setup up a prometheus endpoint
 // 3) add a metric, and create some logs
 // 4) validate that metrics are exported to both otlp servers and at avaialable at the prometheus endpoint
 // 5) validate that `warn` and `error` logs are exported to the unfiltered server and only `error` logs are exported to the filtered server.
-
+#[tokio::test]
 async fn end_to_end_test() {
-    // Setup mock otlp server for filtered logs
-    let filtered_target = MockServer::new(4317);
+    // Setup mock otlp servers for filtered logs
+    let self_signed_cert = generate_self_signed_cert();
+
+    let filtered_target = MockServer::new(free_local_port_in_range(10000..=10100).unwrap(), None);
     tokio::spawn(async {
         filtered_target.server.run().await;
     });
+    let filtered_target_with_tls = MockServer::new(
+        free_local_port_in_range(10100..=10200).unwrap(),
+        Some(self_signed_cert.clone()),
+    );
+    tokio::spawn(async {
+        filtered_target_with_tls.server.run().await;
+    });
 
-    // Setup mock otlp server for unfiltered logs
-    let unfiltered_target = MockServer::new(4318);
+    // Setup mock otlp servers for unfiltered logs
+    let unfiltered_target = MockServer::new(free_local_port_in_range(10200..=10300).unwrap(), None);
     tokio::spawn(async {
         unfiltered_target.server.run().await;
     });
+    let unfiltered_target_with_tls = MockServer::new(
+        free_local_port_in_range(10300..=10400).unwrap(),
+        Some(self_signed_cert.clone()),
+    );
+    tokio::spawn(async {
+        unfiltered_target_with_tls.server.run().await;
+    });
 
     // Setup Otel-lib
-    let prometheus_config = Some(Prometheus { port: 9090 });
+    let prom_port = free_local_port_in_range(10400..=10500).unwrap();
+    let prometheus_config = Some(Prometheus { port: prom_port });
 
     let metric_targets = vec![
         MetricsExportTarget {
@@ -63,11 +80,25 @@ async fn end_to_end_test() {
             ca_cert_path: None,
         },
         MetricsExportTarget {
+            url: filtered_target_with_tls.endpoint.clone(),
+            interval_secs: 1,
+            timeout: 5,
+            temporality: Some(Temporality::Cumulative),
+            ca_cert_path: Some(self_signed_cert.get_ca_cert_path()),
+        },
+        MetricsExportTarget {
             url: unfiltered_target.endpoint.clone(),
             interval_secs: 1,
             timeout: 5,
             temporality: Some(Temporality::Delta),
             ca_cert_path: None,
+        },
+        MetricsExportTarget {
+            url: unfiltered_target_with_tls.endpoint.clone(),
+            interval_secs: 1,
+            timeout: 5,
+            temporality: Some(Temporality::Delta),
+            ca_cert_path: Some(self_signed_cert.get_ca_cert_path()),
         },
     ];
 
@@ -80,11 +111,25 @@ async fn end_to_end_test() {
             ca_cert_path: None,
         },
         LogsExportTarget {
+            url: filtered_target_with_tls.endpoint.clone(),
+            interval_secs: 1,
+            timeout: 5,
+            export_severity: Some(Severity::Error),
+            ca_cert_path: Some(self_signed_cert.get_ca_cert_path()),
+        },
+        LogsExportTarget {
             url: unfiltered_target.endpoint,
             interval_secs: 1,
             timeout: 5,
             export_severity: None,
             ca_cert_path: None,
+        },
+        LogsExportTarget {
+            url: unfiltered_target_with_tls.endpoint,
+            interval_secs: 1,
+            timeout: 5,
+            export_severity: None,
+            ca_cert_path: Some(self_signed_cert.get_ca_cert_path()),
         },
     ];
 
@@ -105,22 +150,29 @@ async fn end_to_end_test() {
         ..Config::default()
     };
 
-    let otel_component = Otel::new(config);
-    let otel_long_running_task = otel_component.run();
+    let otel_component = Arc::new(Otel::new(config));
+    let otel_component_clone = otel_component.clone();
+    let otel_long_running_task = tokio::spawn(async move { otel_component_clone.run().await });
     let run_tests_task = run_tests(
         filtered_target.metrics_rx,
+        filtered_target_with_tls.metrics_rx,
         filtered_target.logs_rx,
+        filtered_target_with_tls.logs_rx,
         unfiltered_target.metrics_rx,
+        unfiltered_target_with_tls.metrics_rx,
         unfiltered_target.logs_rx,
+        unfiltered_target_with_tls.logs_rx,
         &sample_attribute,
+        prom_port,
     );
 
     // run tests
     tokio::select! {
-        () = otel_long_running_task => {
+        _ = otel_long_running_task => {
             panic!("Otel component ended unexpectedly");
         },
-        () = run_tests_task => {
+        _ = run_tests_task => {
+
         }
     }
 
@@ -128,61 +180,55 @@ async fn end_to_end_test() {
 
     filtered_target.shutdown_tx.send(()).await.unwrap();
     unfiltered_target.shutdown_tx.send(()).await.unwrap();
+    self_signed_cert.cleanup();
 }
 
 async fn run_tests(
-    mut filtered_metrics_rx: Receiver<ExportMetricsServiceRequest>,
-    mut filtered_logs_rx: Receiver<ExportLogsServiceRequest>,
-    mut unfiltered_metrics_rx: Receiver<ExportMetricsServiceRequest>,
-    mut unfiltered_logs_rx: Receiver<ExportLogsServiceRequest>,
+    filtered_metrics_rx: Receiver<ExportMetricsServiceRequest>,
+    filtered_metrics_with_tls_rx: Receiver<ExportMetricsServiceRequest>,
+    filtered_logs_rx: Receiver<ExportLogsServiceRequest>,
+    filtered_logs_with_tls_rx: Receiver<ExportLogsServiceRequest>,
+
+    unfiltered_metrics_rx: Receiver<ExportMetricsServiceRequest>,
+    unfiltered_metrics_with_tls_rx: Receiver<ExportMetricsServiceRequest>,
+    unfiltered_logs_rx: Receiver<ExportLogsServiceRequest>,
+    unfiltered_logs_with_tls_rx: Receiver<ExportLogsServiceRequest>,
     sample_attribute: &Attribute,
+    prom_port: u16,
 ) {
     let meter = global::meter_provider().meter("end_to_end_test");
     let test_counter = meter.u64_counter("test_counter").init();
     test_counter.add(1, &[]);
 
-    // validate that the metric is exported to the OTLP target
-    let metrics_export_request = timeout(Duration::from_secs(2), filtered_metrics_rx.recv())
-        .await
-        .unwrap()
-        .unwrap();
-    let (name, value, temporality) = get_counter(&metrics_export_request);
-    assert_eq!(name, "test_counter");
-    assert_eq!(value, 1);
-    assert_eq!(AggregationTemporality::Cumulative, temporality);
+    // validate that the metric is exported to the OTLP targets
+    validate_test_counter(
+        filtered_metrics_rx,
+        sample_attribute,
+        AggregationTemporality::Cumulative,
+    )
+    .await;
+    validate_test_counter(
+        filtered_metrics_with_tls_rx,
+        sample_attribute,
+        AggregationTemporality::Cumulative,
+    )
+    .await;
 
-    let kv = KeyValue {
-        key: sample_attribute.key.clone(),
-        value: Some(AnyValue {
-            value: Some(StringValue(sample_attribute.value.clone())),
-        }),
-    };
-    //validate resource attribute
-    assert!(get_resource_attributes(&metrics_export_request).contains(&kv));
-
-    // validate that the metric is exported to the unfiltered OTLP target
-    let metrics_export_request = timeout(Duration::from_secs(2), unfiltered_metrics_rx.recv())
-        .await
-        .unwrap()
-        .unwrap();
-    let (name, value, temporality) = get_counter(&metrics_export_request);
-    assert_eq!(name, "test_counter");
-    assert_eq!(value, 1);
-    assert_eq!(AggregationTemporality::Delta, temporality);
-    assert!(get_resource_attributes(&metrics_export_request).contains(&kv));
+    validate_test_counter(
+        unfiltered_metrics_rx,
+        sample_attribute,
+        AggregationTemporality::Delta,
+    )
+    .await;
+    validate_test_counter(
+        unfiltered_metrics_with_tls_rx,
+        sample_attribute,
+        AggregationTemporality::Delta,
+    )
+    .await;
 
     // validate the metric is available at the prom endpoint
-    let body = reqwest::get("http://127.0.0.1:9090/metrics")
-        .await
-        .unwrap()
-        .text()
-        .await
-        .unwrap();
-
-    assert!(
-        body.contains("test_counter_total{otel_scope_name=\"end_to_end_test\"} 1"),
-        "did not find expected metric test_counter in server response",
-    );
+    validate_test_counter_prometheus(prom_port).await;
 
     // test logs
 
@@ -199,52 +245,22 @@ async fn run_tests(
     error!("{error_log}"); // should be logged by otel-lib and exported to both OTLP targets
 
     // Check that the filtered target only receives the error log
-    let logs_export_request = timeout(Duration::from_secs(2), filtered_logs_rx.recv())
-        .await
-        .unwrap()
-        .unwrap();
-    let mut log_messages = get_log_messages(&logs_export_request);
-    assert_eq!(log_messages.len(), 1);
-    assert_eq!(
-        log_messages.pop().unwrap(),
-        Value::StringValue(error_log.to_owned())
-    );
+    validate_filtered_logs(filtered_logs_rx, error_log.to_owned()).await;
+    validate_filtered_logs(filtered_logs_with_tls_rx, error_log.to_owned()).await;
 
-    // check that no more messages are received.
-    assert!(timeout(Duration::from_secs(2), filtered_logs_rx.recv())
-        .await
-        .is_err());
-
-    let logs_export_request = timeout(Duration::from_secs(2), unfiltered_logs_rx.recv())
-        .await
-        .unwrap()
-        .unwrap();
-    let mut log_messages = get_log_messages(&logs_export_request);
-    // If not all logs received, wait for the next export.
-    if log_messages.len() == 1 {
-        let logs_export_request = timeout(Duration::from_secs(2), unfiltered_logs_rx.recv())
-            .await
-            .unwrap()
-            .unwrap();
-        let messages = get_log_messages(&logs_export_request);
-        for message in messages {
-            log_messages.push(message);
-        }
-    }
-    assert_eq!(log_messages.len(), 2);
-    assert_eq!(
-        log_messages.pop().unwrap(),
-        Value::StringValue(error_log.to_owned())
-    );
-    assert_eq!(
-        log_messages.pop().unwrap(),
-        Value::StringValue(warn_log.to_owned())
-    );
-
-    // check that no more messages are received.
-    assert!(timeout(Duration::from_secs(2), unfiltered_logs_rx.recv())
-        .await
-        .is_err());
+    // Check that the unfiltered target receives both warn and error log
+    validate_unfiltered_logs(
+        unfiltered_logs_rx,
+        error_log.to_owned(),
+        warn_log.to_owned(),
+    )
+    .await;
+    validate_unfiltered_logs(
+        unfiltered_logs_with_tls_rx,
+        error_log.to_owned(),
+        warn_log.to_owned(),
+    )
+    .await;
 }
 
 fn get_log_messages(logs_export_request: &ExportLogsServiceRequest) -> Vec<Value> {
@@ -292,4 +308,94 @@ fn get_resource_attributes(metrics_export_request: &ExportMetricsServiceRequest)
         .clone()
         .unwrap()
         .attributes
+}
+
+async fn validate_test_counter(
+    mut metrics_rx: Receiver<ExportMetricsServiceRequest>,
+    sample_attribute: &Attribute,
+    export_temporality: AggregationTemporality,
+) {
+    // validate that the metric is exported to the OTLP target
+    let metrics_export_request = timeout(Duration::from_secs(2), metrics_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let (name, value, temporality) = get_counter(&metrics_export_request);
+    assert_eq!(name, "test_counter");
+    assert_eq!(value, 1);
+    assert_eq!(export_temporality, temporality);
+
+    let kv = KeyValue {
+        key: sample_attribute.key.clone(),
+        value: Some(AnyValue {
+            value: Some(StringValue(sample_attribute.value.clone())),
+        }),
+    };
+    //validate resource attribute
+    assert!(get_resource_attributes(&metrics_export_request).contains(&kv));
+}
+
+async fn validate_test_counter_prometheus(prom_port: u16) {
+    // validate the metric is available at the prom endpoint
+    let body = reqwest::get(format!("http://127.0.0.1:{prom_port}/metrics"))
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    assert!(
+        body.contains("test_counter_total{otel_scope_name=\"end_to_end_test\"} 1"),
+        "did not find expected metric test_counter in server response",
+    );
+}
+
+async fn validate_filtered_logs(
+    mut filtered_logs_rx: Receiver<ExportLogsServiceRequest>,
+    error_log: String,
+) {
+    // Check that the filtered target only receives the error log
+    let logs_export_request = timeout(Duration::from_secs(2), filtered_logs_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let mut log_messages = get_log_messages(&logs_export_request);
+    assert_eq!(log_messages.len(), 1);
+    assert_eq!(log_messages.pop().unwrap(), Value::StringValue(error_log));
+
+    // check that no more messages are received.
+    assert!(timeout(Duration::from_secs(2), filtered_logs_rx.recv())
+        .await
+        .is_err());
+}
+
+async fn validate_unfiltered_logs(
+    mut logs_rx: Receiver<ExportLogsServiceRequest>,
+    error_log: String,
+    warn_log: String,
+) {
+    let logs_export_request = timeout(Duration::from_secs(2), logs_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let mut log_messages = get_log_messages(&logs_export_request);
+    // If not all logs received, wait for the next export.
+    if log_messages.len() == 1 {
+        let logs_export_request = timeout(Duration::from_secs(2), logs_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let messages = get_log_messages(&logs_export_request);
+        for message in messages {
+            log_messages.push(message);
+        }
+    }
+    assert_eq!(log_messages.len(), 2);
+    assert_eq!(log_messages.pop().unwrap(), Value::StringValue(error_log));
+    assert_eq!(log_messages.pop().unwrap(), Value::StringValue(warn_log));
+
+    // check that no more messages are received.
+    assert!(timeout(Duration::from_secs(2), logs_rx.recv())
+        .await
+        .is_err());
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -38,6 +38,7 @@ mod mocks;
 // 4) validate that metrics are exported to both otlp servers and at avaialable at the prometheus endpoint
 // 5) validate that `warn` and `error` logs are exported to the unfiltered server and only `error` logs are exported to the filtered server.
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn end_to_end_test() {
     // Setup mock otlp servers for filtered logs
     let self_signed_cert = generate_self_signed_cert();
@@ -171,7 +172,7 @@ async fn end_to_end_test() {
         _ = otel_long_running_task => {
             panic!("Otel component ended unexpectedly");
         },
-        _ = run_tests_task => {
+        () = run_tests_task => {
 
         }
     }
@@ -180,9 +181,10 @@ async fn end_to_end_test() {
 
     filtered_target.shutdown_tx.send(()).await.unwrap();
     unfiltered_target.shutdown_tx.send(()).await.unwrap();
-    self_signed_cert.cleanup();
+    let () = self_signed_cert.cleanup();
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_tests(
     filtered_metrics_rx: Receiver<ExportMetricsServiceRequest>,
     filtered_metrics_with_tls_rx: Receiver<ExportMetricsServiceRequest>,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -60,12 +60,14 @@ async fn end_to_end_test() {
             interval_secs: 1,
             timeout: 5,
             temporality: Some(Temporality::Cumulative),
+            ca_cert_path: None,
         },
         MetricsExportTarget {
             url: unfiltered_target.endpoint.clone(),
             interval_secs: 1,
             timeout: 5,
             temporality: Some(Temporality::Delta),
+            ca_cert_path: None,
         },
     ];
 
@@ -75,12 +77,14 @@ async fn end_to_end_test() {
             interval_secs: 1,
             timeout: 5,
             export_severity: Some(Severity::Error),
+            ca_cert_path: None,
         },
         LogsExportTarget {
             url: unfiltered_target.endpoint,
             interval_secs: 1,
             timeout: 5,
             export_severity: None,
+            ca_cert_path: None,
         },
     ];
 

--- a/tests/mocks.rs
+++ b/tests/mocks.rs
@@ -3,7 +3,12 @@
 
 #![warn(clippy::all, clippy::pedantic)]
 
-use std::net::SocketAddr;
+use std::{
+    fs::{read, remove_file, File},
+    io::Write,
+    net::SocketAddr,
+    path::PathBuf,
+};
 
 use opentelemetry_proto::tonic::collector::{
     logs::v1::{
@@ -17,7 +22,12 @@ use opentelemetry_proto::tonic::collector::{
 };
 
 use tokio::sync::mpsc::{self, Receiver, Sender};
-use tonic::{async_trait, transport::Server, Request, Response, Status};
+use tonic::{
+    async_trait,
+    transport::{Identity, Server, ServerTlsConfig},
+    Request, Response, Status,
+};
+use uuid::Uuid;
 
 pub struct MockServer {
     pub endpoint: String,
@@ -34,10 +44,15 @@ impl MockServer {
     /// # Panics
     ///
     /// Will panic if socketaddr parse fails
-    pub fn new(port: u16) -> Self {
+    pub fn new(port: u16, self_signed_cert: Option<SelfSignedCert>) -> Self {
         // Setup mock otlp server
         let socketaddr = format!("127.0.0.1:{port}");
-        let endpoint = format!("http://localhost:{port}");
+
+        let endpoint = if self_signed_cert.is_some() {
+            format!("https://localhost:{port}")
+        } else {
+            format!("http://localhost:{port}")
+        };
 
         let (metrics_tx, metrics_rx) = mpsc::channel(10);
         let (logs_tx, logs_rx) = mpsc::channel(10);
@@ -47,6 +62,7 @@ impl MockServer {
             shutdown_rx,
             metrics_tx,
             logs_tx,
+            self_signed_cert,
         );
 
         Self {
@@ -64,6 +80,7 @@ pub struct OtlpServer {
     shutdown_rx: Receiver<()>,
     echo_metric_tx: Sender<ExportMetricsServiceRequest>,
     echo_logs_tx: Sender<ExportLogsServiceRequest>,
+    self_signed_cert: Option<SelfSignedCert>,
 }
 
 impl OtlpServer {
@@ -72,12 +89,14 @@ impl OtlpServer {
         shutdown_rx: Receiver<()>,
         echo_metric_tx: Sender<ExportMetricsServiceRequest>,
         echo_logs_tx: Sender<ExportLogsServiceRequest>,
+        self_signed_cert: Option<SelfSignedCert>,
     ) -> Self {
         Self {
             endpoint,
             shutdown_rx,
             echo_metric_tx,
             echo_logs_tx,
+            self_signed_cert,
         }
     }
 
@@ -87,7 +106,17 @@ impl OtlpServer {
     /// Will panic if the port is already in use
     ///
     pub async fn run(self) {
-        let () = Server::builder()
+        let mut server_builder = Server::builder();
+
+        if let Some(self_signed_cert) = self.self_signed_cert {
+            let cert_bytes = read(&self_signed_cert.server_cert_path).unwrap();
+            let key_bytes = read(&self_signed_cert.server_key_path).unwrap();
+            let mut tls_config = ServerTlsConfig::new();
+            tls_config = tls_config.identity(Identity::from_pem(&cert_bytes, &key_bytes));
+            server_builder = server_builder.tls_config(tls_config).unwrap();
+        }
+
+        let () = server_builder
             .add_service(MetricsServiceServer::new(MockMetricsService::new(
                 self.echo_metric_tx,
             )))
@@ -102,6 +131,46 @@ impl OtlpServer {
 
 async fn recv_wrapper(mut receiver: Receiver<()>) {
     let _ = receiver.recv().await;
+}
+
+#[derive(Clone)]
+pub struct SelfSignedCert {
+    pub server_cert_path: PathBuf,
+    pub server_key_path: PathBuf,
+    pub ca_cert_path: PathBuf,
+}
+
+impl SelfSignedCert {
+    pub fn cleanup(&self) {
+        remove_file(&self.server_cert_path).unwrap();
+        remove_file(&self.server_key_path).unwrap();
+    }
+
+    pub fn get_ca_cert_path(&self) -> String {
+        self.ca_cert_path.to_string_lossy().into_owned()
+    }
+}
+
+pub fn generate_self_signed_cert() -> SelfSignedCert {
+    let prefix = Uuid::new_v4();
+    // Generate a self-signed cert and key
+    let cert =
+        rcgen::generate_simple_self_signed(vec!["localhost".into(), "127.0.0.1".into()]).unwrap();
+    let cert_pem = cert.serialize_pem().unwrap();
+    let cert_path = PathBuf::from(format!("./{prefix}_cert.pem"));
+    let mut cert_file = File::create(cert_path.clone()).unwrap();
+    cert_file.write_all(cert_pem.as_bytes()).unwrap();
+
+    let key_pem = cert.serialize_private_key_pem();
+    let key_path = PathBuf::from(format!("./{prefix}_key.pem"));
+    let mut key_file = File::create(key_path.clone()).unwrap();
+    key_file.write_all(key_pem.as_bytes()).unwrap();
+
+    SelfSignedCert {
+        server_cert_path: cert_path.clone(),
+        server_key_path: key_path,
+        ca_cert_path: cert_path,
+    }
 }
 
 struct MockLogsService {


### PR DESCRIPTION
Summary of changes
- Weave in support for export to OTLP targets with TLS
-  Adjust config to accept a CA-CERT path for self-signed certs
-  Expand integration test to cover TLS destinations.