### PR TITLE
Fix a new cargo clippy

### DIFF
--- a/src/filtered_log_processor.rs
+++ b/src/filtered_log_processor.rs
@@ -216,11 +216,11 @@ impl<R: RuntimeChannel> FilteredBatchLogProcessor<R> {
     }
 }
 
-async fn export_with_timeout<'a, R, E>(
+async fn export_with_timeout<R, E>(
     time_out: Duration,
     exporter: &mut E,
     runtime: &R,
-    batch: Vec<Cow<'a, LogData>>,
+    batch: Vec<Cow<'_, LogData>>,
 ) -> ExportResult
 where
     R: RuntimeChannel,


### PR DESCRIPTION
Issue with the latest 1.85 where the lifetime annotation isn't needed.