### PR TITLE
Add a meter provider to provide flexibility to use multiple meter providers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,12 @@ impl Otel {
         }
     }
 
+    /// Returns the meter provider for the otel component
+    /// Gives users flexibility to handle multiple meter providers
+    pub fn get_meter_provider(&self) -> SdkMeterProvider {
+        self.meter_provider.clone()
+    }
+
     /// Long running tasks for otel propagation.
     ///
     /// # Errors


### PR DESCRIPTION
Usecase:
We want to route different metrics to different endpoints. Without having a separate meter provider, it is not possible to route metrics to different endpoints. Hence, we are exposing a method that gives access to the meter provider. This way we will be able to create two different meters that can handle exporting metrics to respective Otel collector endpoints.