### PR TITLE
Add ShutdownHandle to Otel to gracefully shutdown component while it is running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,5 +397,8 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 
+# Cargo build artifacts
+target/
+
 # Cargo lock
 Cargo.lock

--- a/examples/sample-app/src/main.rs
+++ b/examples/sample-app/src/main.rs
@@ -65,7 +65,8 @@ async fn main() {
         ..Config::default()
     };
 
-    let (mut otel_component, shutdown_handle) = Otel::with_shutdown_handle(config);
+    let mut otel_component = Otel::new(config);
+    let shutdown_handle = otel_component.shutdown_handle();
     // Start the otel running task
     let otel_long_running_task = otel_component.run();
     // initialize static metrics

--- a/examples/sample-app/src/main.rs
+++ b/examples/sample-app/src/main.rs
@@ -65,7 +65,7 @@ async fn main() {
         ..Config::default()
     };
 
-    let (mut otel_component, shutdown_tx) = Otel::new(config);
+    let (mut otel_component, shutdown_handle) = Otel::with_shutdown_handle(config);
     // Start the otel running task
     let otel_long_running_task = otel_component.run();
     // initialize static metrics
@@ -96,7 +96,7 @@ async fn main() {
     });
 
     let _ = join!(instrumentation_task, otel_long_running_task);
-    let _ = shutdown_tx.send(()).await;
+    let _ = shutdown_handle.shutdown().await;
 }
 
 #[derive(Parser, Debug)]

--- a/examples/sample-app/src/main.rs
+++ b/examples/sample-app/src/main.rs
@@ -41,6 +41,7 @@ async fn main() {
                 interval_secs: 1,
                 timeout: 5,
                 export_severity: Some(Severity::Error),
+                target_filters: None,
                 ca_cert_path: args.ca_cert_path,
                 bearer_token_provider_fn: Some(get_dummy_bearer_token),
             }];
@@ -64,7 +65,7 @@ async fn main() {
         ..Config::default()
     };
 
-    let mut otel_component = Otel::new(config);
+    let (mut otel_component, shutdown_tx) = Otel::new(config);
     // Start the otel running task
     let otel_long_running_task = otel_component.run();
     // initialize static metrics
@@ -95,7 +96,7 @@ async fn main() {
     });
 
     let _ = join!(instrumentation_task, otel_long_running_task);
-    otel_component.shutdown().await;
+    let _ = shutdown_tx.send(()).await;
 }
 
 #[derive(Parser, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,10 @@ impl Otel {
         Ok(())
     }
 
+    /// Convenience function to trigger shutdown from the Otel struct directly.
+    ///
+    /// # Errors
+    /// * `mpsc::error::SendError` - If the shutdown signal could not be sent
     pub async fn shutdown(&self) -> Result<(), mpsc::error::SendError<()>> {
         self.shutdown_tx.send(()).await // Just sends signal, run() handles the rest
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ impl Otel {
     }
 
     pub async fn shutdown(&self) -> Result<(), mpsc::error::SendError<()>> {
-        self.shutdown_tx.send(()).await  // Just sends signal, run() handles the rest
+        self.shutdown_tx.send(()).await // Just sends signal, run() handles the rest
     }
 }
 
@@ -526,27 +526,31 @@ mod tests {
             // Arrange
             let config = Config::default();
             let (mut otel, shutdown_tx) = Otel::new(config);
-            
-            let run_task = tokio::spawn(async move {
-                otel.run().await
-            });
-            
+
+            let run_task = tokio::spawn(async move { otel.run().await });
+
             tokio::time::sleep(Duration::from_millis(50)).await;
-            
+
             // Act
-            shutdown_tx.send(()).await.expect("Should be able to send shutdown signal");
-            
+            shutdown_tx
+                .send(())
+                .await
+                .expect("Should be able to send shutdown signal");
+
             // Assert
             let result = timeout(Duration::from_secs(1), run_task).await;
-            assert!(result.is_ok(), "Run task should complete after direct shutdown");
+            assert!(
+                result.is_ok(),
+                "Run task should complete after direct shutdown"
+            );
             assert!(result.unwrap().is_ok(), "Run task should exit cleanly");
         }
-        
+
         {
             // Arrange
-            let config = Config::default(); 
+            let config = Config::default();
             let (otel, _shutdown_tx) = Otel::new(config);
-            
+
             // Act
             let shutdown_result = otel.shutdown().await;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,10 +161,10 @@ impl Otel {
                 info!("shutting down otel component");
 
                 if let Err(metrics_error) = self.meter_provider.force_flush() {
-                    warn!("ecountered error while flushing metrics: {metrics_error:?}");
+                    warn!("encountered error while flushing metrics: {metrics_error:?}");
                 }
                 if let Err(metrics_error) = self.meter_provider.shutdown() {
-                    warn!("ecountered error while shutting down meter provider: {metrics_error:?}");
+                    warn!("encountered error while shutting down meter provider: {metrics_error:?}");
                 }
 
                 if let Some(logger_provider) = self.logger_provider.clone() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,20 +71,6 @@ impl ShutdownHandle {
     pub async fn shutdown(&self) -> Result<(), mpsc::error::SendError<()>> {
         self.sender.send(()).await
     }
-
-    /// Get a clone of the shutdown sender for use in other contexts
-    #[must_use]
-    pub fn sender(&self) -> mpsc::Sender<()> {
-        self.sender.clone()
-    }
-
-    /// Clone shutdown handle to share shutdown capability
-    #[must_use]
-    pub fn clone_handle(&self) -> Self {
-        Self {
-            sender: self.sender.clone(),
-        }
-    }
 }
 
 impl Otel {
@@ -593,41 +579,6 @@ mod tests {
 
             // Assert
             assert!(shutdown_result.is_ok(), "Convenience shutdown should work");
-        }
-    }
-
-    #[tokio::test]
-    async fn test_both_constructor_patterns() {
-        // Pattern 1: Simple constructor - returns only Otel instance
-        {
-            let otel = Otel::new(Config::default());
-
-            // Get shutdown handle after construction
-            let handle1 = otel.shutdown_handle();
-            let handle2 = otel.shutdown_handle(); // Can get multiple handles
-
-            // Both handles should work
-            let _sender1 = handle1.sender();
-            let _sender2 = handle2.sender();
-
-            // Direct shutdown also available
-            let _result = otel.shutdown().await;
-        }
-
-        // Pattern 2: Constructor with explicit handle - returns tuple
-        {
-            let otel = Otel::new(Config::default());
-            let initial_handle = otel.shutdown_handle();
-
-            // Can use the initial handle
-            let _sender1 = initial_handle.sender();
-
-            // Can still get more handles from the instance
-            let additional_handle = otel.shutdown_handle();
-            let _sender2 = additional_handle.sender();
-
-            // All approaches available
-            let _result = otel.shutdown().await;
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,16 +66,20 @@ pub struct ShutdownHandle {
 
 impl ShutdownHandle {
     /// Send a shutdown signal
+    /// # Errors
+    /// * `mpsc::error::SendError` - If the shutdown signal could not be sent
     pub async fn shutdown(&self) -> Result<(), mpsc::error::SendError<()>> {
         self.sender.send(()).await
     }
 
     /// Get a clone of the shutdown sender for use in other contexts
+    #[must_use]
     pub fn sender(&self) -> mpsc::Sender<()> {
         self.sender.clone()
     }
 
     /// Clone shutdown handle to share shutdown capability
+    #[must_use]
     pub fn clone_handle(&self) -> Self {
         Self {
             sender: self.sender.clone(),
@@ -197,6 +201,7 @@ impl Otel {
     }
 
     /// Get a shutdown handle that can be used to trigger shutdown from other contexts.
+    #[must_use]
     pub fn shutdown_handle(&self) -> ShutdownHandle {
         ShutdownHandle {
             sender: self.shutdown_tx.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,14 +129,6 @@ impl Otel {
         }
     }
 
-    /// Alternative constructor that also returns a shutdown handle.
-    #[must_use]
-    pub fn with_shutdown_handle(config: Config) -> (Otel, ShutdownHandle) {
-        let otel = Self::new(config);
-        let handle = otel.shutdown_handle();
-        (otel, handle)
-    }
-
     /// Long running tasks for otel propagation.
     ///
     /// # Errors
@@ -569,7 +561,8 @@ mod tests {
         {
             // Arrange
             let config = Config::default();
-            let (mut otel, shutdown_handle) = Otel::with_shutdown_handle(config);
+            let mut otel = Otel::new(config);
+            let shutdown_handle = otel.shutdown_handle();
 
             let run_task = tokio::spawn(async move { otel.run().await });
 
@@ -623,7 +616,8 @@ mod tests {
 
         // Pattern 2: Constructor with explicit handle - returns tuple
         {
-            let (otel, initial_handle) = Otel::with_shutdown_handle(Config::default());
+            let otel = Otel::new(Config::default());
+            let initial_handle = otel.shutdown_handle();
 
             // Can use the initial handle
             let _sender1 = initial_handle.sender();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -183,7 +183,7 @@ async fn end_to_end_test() {
         ..Config::default()
     };
 
-    let (mut otel_component, _shutdown_tx) = Otel::new(config);
+    let mut otel_component = Otel::new(config);
     let otel_long_running_task = tokio::spawn(async move { otel_component.run().await });
     let run_tests_task = run_tests(
         filtered_target.metrics_rx,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -183,7 +183,7 @@ async fn end_to_end_test() {
         ..Config::default()
     };
 
-    let mut otel_component = Otel::new(config);
+    let (mut otel_component, _shutdown_tx) = Otel::new(config);
     let otel_long_running_task = tokio::spawn(async move { otel_component.run().await });
     let run_tests_task = run_tests(
         filtered_target.metrics_rx,


### PR DESCRIPTION
**Description**
The current sample app that uses `shutdown()` on `Otel` components to gracefully shutdown and flush logs does not compile. This change adds a wrapper function around the `Otel` constructor to return a shutdown handler, which allows more explicit control and ownership of the shutdown handler.

**Changes**
- Add Otel::with_shutdown_handle() to return ShutdownHandle
- Remove redundant shutdown methods, use channel directly
- Centralize graceful shutdown logic in run() method
- Update sample app and tests to use tuple return pattern
- Add target/ directories to .gitignore

**Tests**
Sample app run and works, integration tests pass.