### PR TITLE
Prevent shutdown from blocking broker operator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,6 +307,7 @@ fn init_metrics(config: Config) -> (Option<PrometheusRegistry>, SdkMeterProvider
 
             let reader = PeriodicReader::builder(exporter, runtime::Tokio)
                 .with_interval(Duration::from_secs(export_target.interval_secs))
+                .with_timeout(Duration::from_secs(export_target.timeout))
                 .build();
             meter_provider_builder = meter_provider_builder.with_reader(reader);
         }
@@ -322,7 +323,9 @@ fn init_metrics(config: Config) -> (Option<PrometheusRegistry>, SdkMeterProvider
             })
             .build();
 
-        let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
+        let reader = PeriodicReader::builder(exporter, runtime::Tokio)
+            .with_timeout(Duration::from_secs(30))
+            .build();
         meter_provider_builder = meter_provider_builder.with_reader(reader);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@ impl TemporalitySelector for DeltaTemporalitySelector {
 /// setup the stdout metrics writer if enabled, and initializes STATIC Metrics.
 ///
 /// Returns the Prometheus Registry or None if Prometheus was disabled.
-///
+#[allow(clippy::too_many_lines)]
 fn init_metrics(config: Config) -> (Option<PrometheusRegistry>, SdkMeterProvider) {
     let mut keys = vec![KeyValue::new(SERVICE_NAME_KEY, config.service_name.clone())];
     if let Some(resource_attributes) = config.resource_attributes {


### PR DESCRIPTION
This change adds timeouts to `Otel::shutdown()` logic. There is a bug where when attempting to flush the otel logs when the server is not available the shutdown tasks hangs indefinitely and causes the broker operator to stall.

Testing:
- Locally consuming this change in Azure-MQ no longer causes the broker operator pod/statefulset to get stuck in a nonready state if it is installed using otel and gRPC arguments. Testing the same broker images off of `Otel-lib/main` reproduces the issue.